### PR TITLE
simplify HealthOmics notebook

### DIFF
--- a/store-multimodal-data/genomic/store-analyze-genomicdata-with-awshealthomics.ipynb
+++ b/store-multimodal-data/genomic/store-analyze-genomicdata-with-awshealthomics.ipynb
@@ -11,7 +11,7 @@
    "id": "3c8ef7a7",
    "metadata": {},
    "source": [
-    "# Create Amazon Omics Analytic Stores to Import Genomic Data and Run Queries"
+    "# Create AWS HealthOmics Analytic Stores to Import Genomic Data and Run Queries"
    ]
   },
   {
@@ -19,7 +19,10 @@
    "id": "85d3918d",
    "metadata": {},
    "source": [
-    "### Follow steps in this notebook to: 1) create Amazon Omics Reference, Variant, and Annotation Stores; 2) import reference genome, variant files, and ClinVar annotation file from S3 to the respective data stores; 3) query the variant and annotation data. "
+    "Follow steps in this notebook to:\n",
+    "1. create AWS HealthOmics Reference, Variant, and Annotation Stores\n",
+    "2. import reference genome, variant files, and ClinVar annotation file from S3 to the respective data stores\n",
+    "3. query the variant and annotation data. "
    ]
   },
   {
@@ -27,28 +30,36 @@
    "id": "aef34065",
    "metadata": {},
    "source": [
-    "## Create reference store and import reference genome"
+    "## Prerequisites and package dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fee6df5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install awswrangler"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
    "id": "2dee102e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from datetime import datetime\n",
-    "import itertools as it\n",
-    "import json\n",
-    "import gzip\n",
-    "import os\n",
     "from pprint import pprint\n",
-    "import time\n",
     "import urllib\n",
     "\n",
     "import boto3\n",
     "import botocore.exceptions\n",
-    "import requests"
+    "\n",
+    "from utils import *"
    ]
   },
   {
@@ -63,7 +74,12 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "a036d0a8",
-   "metadata": {},
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# set a timestamp\n",
@@ -123,71 +139,14 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "9eb174a7",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Base name for role and policy\n",
     "omics_iam_name = f'multimodal-omics-{ts}'\n",
-    "\n",
-    "# Create the IAM client\n",
-    "iam = boto3.resource('iam')\n",
-    "\n",
-    "# Check if the role already exist. If not, create it\n",
-    "try:\n",
-    "    role = iam.Role(omics_iam_name)\n",
-    "    role.load()\n",
-    "    \n",
-    "except botocore.exceptions.ClientError as ex:\n",
-    "    if ex.response[\"Error\"][\"Code\"] == \"NoSuchEntity\":\n",
-    "        #Create the role with the corresponding trust policy\n",
-    "        role = iam.create_role(\n",
-    "            RoleName=omics_iam_name, \n",
-    "            AssumeRolePolicyDocument=json.dumps(trust_policy))\n",
-    "        \n",
-    "        #Create policy\n",
-    "        policy = iam.create_policy(\n",
-    "            PolicyName='{}-policy'.format(omics_iam_name), \n",
-    "            Description=\"Policy for Amazon Omics\",\n",
-    "            PolicyDocument=json.dumps(policy))\n",
-    "        \n",
-    "        #Attach the policy to the role\n",
-    "        policy.attach_role(RoleName=omics_iam_name)\n",
-    "    else:\n",
-    "        print (ex)\n",
-    "        print('Somthing went wrong, please retry and check your account settings and permissions')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "c0a3e04a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_role_arn(role_name):\n",
-    "    try:\n",
-    "        iam = boto3.resource('iam')\n",
-    "        role = iam.Role(role_name)\n",
-    "        role.load()  # calls GetRole to load attributes\n",
-    "    except botocore.exeptions.ClientError:\n",
-    "        print(\"Couldn't get role named %s.\"%role_name)\n",
-    "        raise\n",
-    "    else:\n",
-    "        return role.arn"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 171,
-   "id": "161d02b0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Replace <S3 URI for FASTA file> with the S3 URI of the reference genome in FASTA format. \n",
-    "\n",
-    "SOURCE_S3_URIS = {\n",
-    "    \"reference\": \"<S3 URI for FASTA file>\"\n",
-    "    }"
+    "create_omics_role(omics_iam_name, policy, trust_policy)"
    ]
   },
   {
@@ -200,12 +159,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "c02fcf1f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "omics = boto3.client('omics', region_name='us-east-1')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94b5014a",
+   "metadata": {},
+   "source": [
+    "### Source data\n",
+    "Set the source data bucket to the regional replica of the Synthea Coherent dataset. If you want to use different source data, replace the bucket name here and any S3 URIs where it is used in the rest of the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bfd290d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SOURCE_BUCKET_NAME = f\"guidance-multimodal-hcls-healthai-machinelearning-{omics.meta.region_name}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "adda409b",
+   "metadata": {},
+   "source": [
+    "## Create reference store and import reference genome"
    ]
   },
   {
@@ -218,32 +206,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "1657476d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_ref_store_id(client=None):\n",
-    "    if not client:\n",
-    "        client = boto3.client('omics')\n",
-    "    \n",
-    "    resp = client.list_reference_stores(maxResults=10)\n",
-    "    list_of_stores = resp.get('referenceStores')\n",
-    "    store_id = None\n",
-    "    \n",
-    "    if list_of_stores != None:\n",
-    "        # Since there can only be one store per region, if there is a store present use the first one\n",
-    "        store_id = list_of_stores[0].get('id')\n",
-    "    \n",
-    "    return store_id"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "a3071ab4",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checking for a reference store in region: us-east-1\n",
+      "Congratulations, you have an existing reference store!\n"
+     ]
+    }
+   ],
    "source": [
     "print(f\"Checking for a reference store in region: {omics.meta.region_name}\")\n",
     "if get_ref_store_id(omics) == None:\n",
@@ -263,9 +240,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
+   "id": "161d02b0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "SOURCE_S3_URIS = {\n",
+    "    \"reference\": f\"s3://{SOURCE_BUCKET_NAME}/genomic/reference/hg19.fa\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "id": "6bf75b4f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# If using a different reference genomem, replace \"hg19\" with a different prefix\n",
@@ -286,13 +279,34 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "219c738a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "ref_import_job = omics.get_reference_import_job(\n",
     "    referenceStoreId=get_ref_store_id(omics), \n",
     "    id=ref_import_job['id'])\n",
     "ref_import_job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e1b56ff-92db-4db7-8e5f-f51f5733b557",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    waiter = omics.get_waiter('reference_import_job_completed')\n",
+    "    waiter.wait(id=ref_import_job['id'], referenceStoreId=ref_import_job['referenceStoreId'])\n",
+    "    \n",
+    "    print(f\"reference import job {ref_import_job['id']} complete\")\n",
+    "except botocore.exceptions.WaiterError as e:\n",
+    "    print(f\"reference import job {ref_import_job['id']} FAILED\")\n",
+    "    print(e)"
    ]
   },
   {
@@ -307,7 +321,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "055d8c70",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "resp = omics.list_references(referenceStoreId=get_ref_store_id(omics), filter={\"name\": ref_name})\n",
@@ -320,7 +336,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "41525f3c",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Store this reference\n",
@@ -340,58 +358,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
-   "id": "b0796c2b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_reference_arn(ref_name, client=None):\n",
-    "    if not client:\n",
-    "        client = boto3.client('omics')\n",
-    "    \n",
-    "    resp = client.list_reference_stores(maxResults=10)\n",
-    "    ref_stores = resp.get('referenceStores')\n",
-    "    \n",
-    "    # There can only be one reference store per account per region\n",
-    "    # if there is a store present, it is the first one\n",
-    "    ref_store = ref_stores[0] if ref_stores else None\n",
-    "    \n",
-    "    if not ref_store:\n",
-    "        raise RuntimeError(\"You have not created a reference store, please got to the Amazon Omics Storage tutorial to learn how to create one. Do not continue with this notebook\")\n",
-    "        \n",
-    "    ref_arn = None\n",
-    "    resp = omics.list_references(referenceStoreId=ref_store['id'])\n",
-    "    ref_list = resp.get('references')\n",
-    "    \n",
-    "    for ref in resp.get('references'):\n",
-    "        if ref['name'] == ref_name:\n",
-    "            ref_arn = ref['arn']\n",
-    "    \n",
-    "    if ref_arn == None:\n",
-    "        raise RuntimeError(f\"Could not find {ref_name}.\")\n",
-    "    \n",
-    "    return ref_arn"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 12,
    "id": "01ec4e3d",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "# Replace <S3 URI for VCF files> with the S3 URI of the bucket containing the VCF files. \n",
-    "\n",
-    "SOURCE_VARIANT_URI = \"<S3 URI for VCF files>\""
+    "SOURCE_VARIANT_URI = f\"s3://{SOURCE_BUCKET_NAME}\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": 13,
    "id": "801a2d03",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
+    "# generate a list of VCF files to import\n",
+    "\n",
     "source = urllib.parse.urlparse(SOURCE_VARIANT_URI)\n",
     "bucket = source.netloc\n",
     "prefix = source.path[1:]\n",
@@ -400,7 +387,7 @@
     "\n",
     "bucket = s3r.Bucket(bucket)\n",
     "objects = bucket.objects.filter(Prefix=prefix, MaxKeys=10_000)\n",
-    "ext = '.vcf'\n",
+    "ext = '_dna.vcf'\n",
     "\n",
     "vcf_list = [f\"s3://{o.bucket_name}/{o.key}\" for o in objects if o.key.endswith(ext)]"
    ]
@@ -417,13 +404,12 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9c1fa8fd",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "var_store_name = f'synthea_newvariants_{ts.lower()}'\n",
-    "\n",
-    "# Replace <reference name> with reference genome name created in the previous steps\n",
-    "ref_name = '<reference name>' \n",
     "\n",
     "response = omics.create_variant_store(\n",
     "    name=var_store_name, \n",
@@ -446,7 +432,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3aed46b5",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "try:\n",
@@ -471,9 +459,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 17,
    "id": "73a348de",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "l_vcf = [dict(zip([\"source\"],[uri])) for i, uri in enumerate(vcf_list)]\n",
@@ -494,68 +484,55 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7058ce3f",
-   "metadata": {},
+   "id": "b2db8f94-c240-45da-8671-8370f0067407",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# To run Athena queries on the data, use AWS LakeFormation to create resource links to the database\n",
-    "# and ensure IAM user running this notebook is a Data Lake Administrator.\n",
+    "# For the following function to work, you need to ensure the IAM user running this notebook is a Data Lake Administrator.\n",
     "\n",
-    "ram = boto3.client('ram')\n",
-    "glue = boto3.client('glue')\n",
-    "\n",
-    "caller_identity = boto3.client('sts').get_caller_identity()\n",
-    "AWS_ACCOUNT_ID = caller_identity['Account']\n",
-    "AWS_IDENITY_ARN = caller_identity['Arn']"
+    "create_resource_link('omicsdb', var_store, store_type='variant')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "06fe7107",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "response = ram.list_resources(resourceOwner='OTHER-ACCOUNTS', resourceType='glue:Database')\n",
-    "\n",
-    "if not response.get('resources'):\n",
-    "    print('no shared resources found. verify that you have successfully created an Omics Analytics store')\n",
-    "else:\n",
-    "    variantstore_resources = [resource for resource in response['resources'] if var_store['id'] in resource['arn']]\n",
-    "    if not variantstore_resources:\n",
-    "        print(f\"no shared resources matching variant store id {var_store['id']} found\")\n",
-    "    else:\n",
-    "        variantstore_resource = variantstore_resources[0]\n",
-    "\n",
-    "variantstore_resource\n",
-    "\n",
-    "resource_share = ram.get_resource_shares(\n",
-    "    resourceOwner='OTHER-ACCOUNTS', \n",
-    "    resourceShareArns=[variantstore_resource['resourceShareArn']])['resourceShares'][0]\n",
-    "resource_share\n",
-    "\n",
-    "# this creates a resource link to the table for the variant store and adds it to the `omicsdb` database\n",
-    "glue.create_table(\n",
-    "    DatabaseName='omicsdb',\n",
-    "    TableInput = {\n",
-    "        \"Name\": var_store['name'],\n",
-    "        \"TargetTable\": {\n",
-    "            \"CatalogId\": resource_share['owningAccountId'],\n",
-    "            \"DatabaseName\": f\"variant_{AWS_ACCOUNT_ID}_{var_store['id']}\",\n",
-    "            \"Name\": var_store['name'],\n",
-    "        }\n",
-    "    }\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "e570e5d2",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Athena engine version 3\n",
+      "Workgroup 'omics' found using Athena engine version 3\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'Name': 'omics',\n",
+       " 'State': 'ENABLED',\n",
+       " 'Description': '',\n",
+       " 'CreationTime': datetime.datetime(2023, 3, 21, 20, 36, 59, 255000, tzinfo=tzlocal()),\n",
+       " 'EngineVersion': {'SelectedEngineVersion': 'Athena engine version 3',\n",
+       "  'EffectiveEngineVersion': 'Athena engine version 3'}}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# Use Athena engine version 3 to query Omics Analytic Stores \n",
+    "# Omics Analytic Stores requires Athena engine version 3 for querying\n",
+    "# https://docs.aws.amazon.com/athena/latest/ug/versions.html\n",
+    "\n",
+    "# Locate or create a suitable workgroup for Athena queries\n",
     "\n",
     "athena = boto3.client('athena')\n",
     "\n",
@@ -584,9 +561,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 192,
+   "execution_count": 26,
    "id": "8dbf203d",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -620,7 +599,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>3dcf722a-8e47-dd42-a0f3-97496f4e8d09</td>\n",
+       "      <td>69eab197-6c14-7fcf-16d8-a18a222b82a4</td>\n",
        "      <td>1</td>\n",
        "      <td>46932823</td>\n",
        "      <td>A</td>\n",
@@ -629,7 +608,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>2a19fd41-040b-e9fb-fb5c-e9095f04922e</td>\n",
+       "      <td>c7fff683-fd1b-f937-71ae-a490a80c9197</td>\n",
        "      <td>1</td>\n",
        "      <td>46932823</td>\n",
        "      <td>A</td>\n",
@@ -638,16 +617,16 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>b3eaed13-18ab-509f-f9c7-2d0337181c7b</td>\n",
+       "      <td>c7fff683-fd1b-f937-71ae-a490a80c9197</td>\n",
        "      <td>1</td>\n",
-       "      <td>46932823</td>\n",
-       "      <td>A</td>\n",
-       "      <td>[G]</td>\n",
+       "      <td>55039973</td>\n",
+       "      <td>G</td>\n",
+       "      <td>[A, T]</td>\n",
        "      <td>[0, 1]</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>08dc48f1-2321-362b-8c26-9ec0ed06f4fd</td>\n",
+       "      <td>c7fff683-fd1b-f937-71ae-a490a80c9197</td>\n",
        "      <td>1</td>\n",
        "      <td>46932823</td>\n",
        "      <td>A</td>\n",
@@ -656,7 +635,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>a870a2c3-9fd9-7141-6391-b1428fb920bb</td>\n",
+       "      <td>1c906349-d5f7-3b79-9385-291d6ca12ddc</td>\n",
        "      <td>1</td>\n",
        "      <td>46932823</td>\n",
        "      <td>A</td>\n",
@@ -665,7 +644,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>1acc5aa3-ba78-a290-7cf6-75284343ab22</td>\n",
+       "      <td>69eab197-6c14-7fcf-16d8-a18a222b82a4</td>\n",
        "      <td>1</td>\n",
        "      <td>46932823</td>\n",
        "      <td>A</td>\n",
@@ -674,16 +653,16 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td>1d08cfdb-2a91-55bd-4e27-2e88630849f3</td>\n",
+       "      <td>69eab197-6c14-7fcf-16d8-a18a222b82a4</td>\n",
        "      <td>1</td>\n",
-       "      <td>46932823</td>\n",
-       "      <td>A</td>\n",
-       "      <td>[G]</td>\n",
+       "      <td>55039973</td>\n",
+       "      <td>G</td>\n",
+       "      <td>[A, T]</td>\n",
        "      <td>[0, 1]</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td>6df219b3-88cd-b76a-2c14-40a6399152aa</td>\n",
+       "      <td>1c906349-d5f7-3b79-9385-291d6ca12ddc</td>\n",
        "      <td>1</td>\n",
        "      <td>46932823</td>\n",
        "      <td>A</td>\n",
@@ -692,16 +671,16 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
-       "      <td>7a4dad5f-3b06-3104-8540-f20982d2c4c5</td>\n",
+       "      <td>1c906349-d5f7-3b79-9385-291d6ca12ddc</td>\n",
        "      <td>1</td>\n",
-       "      <td>46932823</td>\n",
-       "      <td>A</td>\n",
-       "      <td>[G]</td>\n",
+       "      <td>55039973</td>\n",
+       "      <td>G</td>\n",
+       "      <td>[A, T]</td>\n",
        "      <td>[0, 1]</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
-       "      <td>30fe95e3-951f-ef8c-4b1d-c921a9a6dbdb</td>\n",
+       "      <td>dccfd9ed-8080-2743-5c17-7888e93617d5</td>\n",
        "      <td>1</td>\n",
        "      <td>46932823</td>\n",
        "      <td>A</td>\n",
@@ -714,31 +693,31 @@
       ],
       "text/plain": [
        "                               sampleid contigname     start referenceallele  \\\n",
-       "0  3dcf722a-8e47-dd42-a0f3-97496f4e8d09          1  46932823               A   \n",
-       "1  2a19fd41-040b-e9fb-fb5c-e9095f04922e          1  46932823               A   \n",
-       "2  b3eaed13-18ab-509f-f9c7-2d0337181c7b          1  46932823               A   \n",
-       "3  08dc48f1-2321-362b-8c26-9ec0ed06f4fd          1  46932823               A   \n",
-       "4  a870a2c3-9fd9-7141-6391-b1428fb920bb          1  46932823               A   \n",
-       "5  1acc5aa3-ba78-a290-7cf6-75284343ab22          1  46932823               A   \n",
-       "6  1d08cfdb-2a91-55bd-4e27-2e88630849f3          1  46932823               A   \n",
-       "7  6df219b3-88cd-b76a-2c14-40a6399152aa          1  46932823               A   \n",
-       "8  7a4dad5f-3b06-3104-8540-f20982d2c4c5          1  46932823               A   \n",
-       "9  30fe95e3-951f-ef8c-4b1d-c921a9a6dbdb          1  46932823               A   \n",
+       "0  69eab197-6c14-7fcf-16d8-a18a222b82a4          1  46932823               A   \n",
+       "1  c7fff683-fd1b-f937-71ae-a490a80c9197          1  46932823               A   \n",
+       "2  c7fff683-fd1b-f937-71ae-a490a80c9197          1  55039973               G   \n",
+       "3  c7fff683-fd1b-f937-71ae-a490a80c9197          1  46932823               A   \n",
+       "4  1c906349-d5f7-3b79-9385-291d6ca12ddc          1  46932823               A   \n",
+       "5  69eab197-6c14-7fcf-16d8-a18a222b82a4          1  46932823               A   \n",
+       "6  69eab197-6c14-7fcf-16d8-a18a222b82a4          1  55039973               G   \n",
+       "7  1c906349-d5f7-3b79-9385-291d6ca12ddc          1  46932823               A   \n",
+       "8  1c906349-d5f7-3b79-9385-291d6ca12ddc          1  55039973               G   \n",
+       "9  dccfd9ed-8080-2743-5c17-7888e93617d5          1  46932823               A   \n",
        "\n",
        "  alternatealleles   calls  \n",
        "0              [G]  [0, 1]  \n",
        "1              [G]  [0, 1]  \n",
-       "2              [G]  [0, 1]  \n",
+       "2           [A, T]  [0, 1]  \n",
        "3              [G]  [0, 1]  \n",
        "4              [G]  [0, 1]  \n",
        "5              [G]  [0, 1]  \n",
-       "6              [G]  [0, 1]  \n",
+       "6           [A, T]  [0, 1]  \n",
        "7              [G]  [0, 1]  \n",
-       "8              [G]  [0, 1]  \n",
+       "8           [A, T]  [0, 1]  \n",
        "9              [G]  [0, 1]  "
       ]
      },
-     "execution_count": 192,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -748,10 +727,9 @@
     "\n",
     "import awswrangler as wr\n",
     "\n",
-    "# Replace <variant-table> with the name of the annotation table created in the previous step\n",
-    "\n",
-    "df_var = wr.athena.read_sql_query(\"select sampleid, contigname, start, referenceallele, alternatealleles, calls from <variant-table> limit 10;\", \n",
-    "                              database=\"omicsdb\", workgroup = \"omics\")\n",
+    "df_var = wr.athena.read_sql_query(\n",
+    "    f\"select sampleid, contigname, start, referenceallele, alternatealleles, calls from {var_store['name']} limit 10;\", \n",
+    "    database=\"omicsdb\", workgroup = \"omics\")\n",
     "df_var"
    ]
   },
@@ -767,17 +745,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4b747f19",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "# Replace <S3 URI for annotation file> with the S3 URI of the ClinVar annotation file \n",
-    "\n",
-    "SOURCE_ANNOTATION_URI = \"<S3 URI for annotation file>\"\n",
+    "SOURCE_ANNOTATION_URI = f\"s3://{SOURCE_BUCKET_NAME}/genomic/annotation/clinvar.vcf.gz\"\n",
     "\n",
     "ann_store_name = f'synthea_annotations_{ts.lower()}'\n",
-    "\n",
-    "# Replace <reference name> with reference genome name created in the previous steps\n",
-    "ref_name = '<reference name>' \n",
     "\n",
     "response = omics.create_annotation_store(\n",
     "    name=ann_store_name, \n",
@@ -809,26 +784,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 88,
-   "id": "534c2b53",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "source = urllib.parse.urlparse(SOURCE_ANNOTATION_URI)\n",
-    "bucket = source.netloc\n",
-    "prefix = source.path[1:]\n",
-    "\n",
-    "s3r = boto3.resource('s3')\n",
-    "\n",
-    "bucket = s3r.Bucket(bucket)\n",
-    "objects = bucket.objects.filter(Prefix=prefix, MaxKeys=10_000)\n",
-    "ext = '.vcf'\n",
-    "\n",
-    "annotation_list = [f\"s3://{o.bucket_name}/{o.key}\" for o in objects if o.key.endswith(ext)]"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "167610f7",
    "metadata": {},
@@ -840,7 +795,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "330bff87",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "response = omics.start_annotation_import_job(\n",
@@ -862,46 +819,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b614d7ec",
-   "metadata": {},
+   "id": "8345b58b-bfbd-45b0-93a7-882891f4f53a",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "# To run Athena queries on the data, use AWS LakeFormation to create resource links to the database and \n",
-    "\n",
-    "response = ram.list_resources(resourceOwner='OTHER-ACCOUNTS', resourceType='glue:Database')\n",
-    "\n",
-    "if not response.get('resources'):\n",
-    "    print('no shared resources found. verify that you have successfully created an Omics Analytics store')\n",
-    "else:\n",
-    "    annotationstore_resources = [resource for resource in response['resources'] if ann_store['id'] in resource['arn']]\n",
-    "    if not annotationstore_resources:\n",
-    "        print(f\"no shared resources matching annotation store id {ann_store['id']} found\")\n",
-    "    else:\n",
-    "        annotationstore_resource = annotationstore_resources[0]\n",
-    "\n",
-    "        resource_share = ram.get_resource_shares(\n",
-    "            resourceOwner='OTHER-ACCOUNTS', \n",
-    "            resourceShareArns=[annotationstore_resource['resourceShareArn']])['resourceShares'][0]\n",
-    "        \n",
-    "        # this creates a resource link to the table for the annotation store and adds it to the `omicsdb` database\n",
-    "        glue.create_table(\n",
-    "            DatabaseName='omicsdb',\n",
-    "            TableInput = {\n",
-    "                \"Name\": ann_store['name'],\n",
-    "                \"TargetTable\": {\n",
-    "                    \"CatalogId\": resource_share['owningAccountId'],\n",
-    "                    \"DatabaseName\": f\"annotation_{AWS_ACCOUNT_ID}_{ann_store['id']}\",\n",
-    "                    \"Name\": ann_store['name'],\n",
-    "                }\n",
-    "            }\n",
-    "        )"
+    "create_resource_link('omicsdb', ann_store, store_type='annotation')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": 27,
    "id": "b0f4bf17",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1042,16 +975,15 @@
        "9  [(RS, 1640863258), (CLNSIG, Uncertain_signific...  "
       ]
      },
-     "execution_count": 189,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Replace <annotation-table> with the name of the annotation table created in the previous step\n",
-    "\n",
-    "df_ann = wr.athena.read_sql_query(\"select contigname, start, referenceallele, alternatealleles, attributes from <annotation-table> order by contigname limit 10;\", \n",
-    "                              database=\"omicsdb\", workgroup = \"omics\")\n",
+    "df_ann = wr.athena.read_sql_query(\n",
+    "    f\"select contigname, start, referenceallele, alternatealleles, attributes from {ann_store['name']} order by contigname limit 10;\", \n",
+    "    database=\"omicsdb\", workgroup = \"omics\")\n",
     "df_ann"
    ]
   },
@@ -1088,7 +1020,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/store-multimodal-data/genomic/utils.py
+++ b/store-multimodal-data/genomic/utils.py
@@ -1,0 +1,126 @@
+import json
+
+
+import boto3
+import botocore.exceptions
+
+
+def create_omics_role(rolename, policy, trust_policy, iam=None):
+    # Create the IAM client
+    if not iam:
+        iam = boto3.resource('iam')
+
+    # Check if the role already exist. If not, create it
+    try:
+        role = iam.Role(rolename)
+        role.load()
+
+    except botocore.exceptions.ClientError as ex:
+        if ex.response["Error"]["Code"] == "NoSuchEntity":
+            #Create the role with the corresponding trust policy
+            role = iam.create_role(
+                RoleName=rolename, 
+                AssumeRolePolicyDocument=json.dumps(trust_policy))
+
+            #Create policy
+            policy = iam.create_policy(
+                PolicyName='{}-policy'.format(rolename), 
+                Description="Policy for Amazon Omics",
+                PolicyDocument=json.dumps(policy))
+
+            #Attach the policy to the role
+            policy.attach_role(RoleName=rolename)
+        else:
+            print (ex)
+            print('Somthing went wrong, please retry and check your account settings and permissions')
+
+
+def get_role_arn(rolename, client=None):
+    """retrieves the arn for an iam role name"""
+    if not client:
+        client = boto3.client('iam')
+    
+    role = client.get_role(RoleName=rolename)['Role']
+    return role['Arn']
+
+
+def get_ref_store_id(client=None):
+    if not client:
+        client = boto3.client('omics')
+    
+    resp = client.list_reference_stores(maxResults=10)
+    list_of_stores = resp.get('referenceStores')
+    store_id = None
+    
+    if list_of_stores != None:
+        # Since there can only be one store per region, if there is a store present use the first one
+        store_id = list_of_stores[0].get('id')
+    
+    return store_id
+
+
+def get_reference_arn(ref_name, client=None):
+    if not client:
+        client = boto3.client('omics')
+    
+    resp = client.list_reference_stores(maxResults=10)
+    ref_stores = resp.get('referenceStores')
+    
+    # There can only be one reference store per account per region
+    # if there is a store present, it is the first one
+    ref_store = ref_stores[0] if ref_stores else None
+    
+    if not ref_store:
+        raise RuntimeError("You have not created a reference store, please got to the Amazon Omics Storage tutorial to learn how to create one. Do not continue with this notebook")
+        
+    ref_arn = None
+    resp = client.list_references(referenceStoreId=ref_store['id'])
+    ref_list = resp.get('references')
+    
+    for ref in resp.get('references'):
+        if ref['name'] == ref_name:
+            ref_arn = ref['arn']
+    
+    if ref_arn == None:
+        raise RuntimeError(f"Could not find {ref_name}.")
+    
+    return ref_arn
+
+
+def create_resource_link(database_name, store, store_type='variant'):
+    ram = boto3.client('ram')
+    glue = boto3.client('glue')
+
+    caller_identity = boto3.client('sts').get_caller_identity()
+    AWS_ACCOUNT_ID = caller_identity['Account']
+    AWS_IDENITY_ARN = caller_identity['Arn']
+
+    response = ram.list_resources(resourceOwner='OTHER-ACCOUNTS', resourceType='glue:Database')
+
+    if not response.get('resources'):
+        print('no shared resources found. verify that you have successfully created an Omics Analytics store')
+    else:
+        store_resources = [resource for resource in response['resources'] if store['id'] in resource['arn']]
+        if not store_resources:
+            print(f"no shared resources matching {store_type} store id {store['id']} found")
+        else:
+            store_resource = store_resources[0]
+
+    resource_share = ram.get_resource_shares(
+        resourceOwner='OTHER-ACCOUNTS', 
+        resourceShareArns=[store_resource['resourceShareArn']])['resourceShares'][0]
+    
+    # this creates a resource link to the table for the variant store and adds it to the `omicsdb` database
+    response = glue.create_table(
+        DatabaseName=database_name,
+        TableInput = {
+            "Name": store['name'],
+            "TargetTable": {
+                "CatalogId": resource_share['owningAccountId'],
+                "DatabaseName": f"{store_type}_{AWS_ACCOUNT_ID}_{store['id']}",
+                "Name": store['name'],
+            }
+        }
+    )
+    
+    return store_resource, resource_share, response


### PR DESCRIPTION
*Description of changes:*
Simplified the example notebook for storing and analyzing genomic data with AWS HealthOmics.
- Move helper functions to `utils` module
- Use regionalized source data bucket for S3 URIs
- Refactored cell flow to
  - install and load package dependencies (e.g. awswrangler) at start of notebook
  - establish core resources (Omics IAM Role, Omics client, source bucket name) at start of notebook
  - Focus on Reference import, Variant Import and querying, Annotation import and querying
- cleaned up code comments

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
